### PR TITLE
Fixed broken build

### DIFF
--- a/KernelSDK/src/kernel/KernelBase/Widen.cpp
+++ b/KernelSDK/src/kernel/KernelBase/Widen.cpp
@@ -64,7 +64,7 @@ String QAPI vfs::toLower (const String & str)
 
 String QAPI vfs::widen(const std::string & str)
 {
-  const ctype<wchar_t>& char_facet = _USE(locale(),ctype<wchar_t>);
+  const ctype<wchar_t>& char_facet = std::use_facet<ctype<wchar_t>>(locale());
   String ret;
   ret.reserve(str.size());//avoid incremental allocation
   for(std::string::const_iterator it = str.begin(); it != str.end(); ++it)
@@ -76,7 +76,7 @@ String QAPI vfs::widen(const std::string & str)
 
 std::string QAPI vfs::narrow(const String & str)
 {
-  const ctype<wchar_t>& char_facet = _USE(locale(),ctype<wchar_t>);
+  const ctype<wchar_t>& char_facet = std::use_facet<ctype<wchar_t>>(locale());
   std::string ret;
   ret.reserve(str.size());//avoid incremental allocation
   for(String::const_iterator it = str.begin(); it != str.end(); ++it)

--- a/QCIFSServer/QCIFSFwk/cGenTreeResource.cpp
+++ b/QCIFSServer/QCIFSFwk/cGenTreeResource.cpp
@@ -458,7 +458,7 @@ DWORD cGenTreeResource::getBytesPerCluster()
   return m_pShare->bytesPerSector() * m_pShare->sectorsPerCluster();
 }
 
-inline cPtr<iDirLocation> cGenTreeResource::get(const String& sPath) const
+cPtr<iDirLocation> cGenTreeResource::get(const String& sPath) const
 {
   if (m_pShare.isValid())
     return m_pShare->get(sPath);


### PR DESCRIPTION
The build of both KernelBase and QCIFSFwk projects were broken on Visual Studio 2017 (toolset 141). This is an attempt to fix it.